### PR TITLE
Refactor filter components and add counter functionality

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -144,20 +144,6 @@ function AppContent({ lang, setLang }) {
     }
   }, [allItems, badges]);
 
-  // Fonction pour charger et filtrer les EOVs traduits
-  const fetchAndFilterEovsTranslated = useCallback(async (lang, eovList) => {
-    const res = await fetch(basePath + "/eovs.json");
-    const data = await res.json();
-    const eovs = data.eovs;
-
-    const labelkey = `label_${lang}`;
-    const filtered = eovs
-      .filter((eov) => eovList.includes(eov.value)) // comparez par value qui correspond à l'identifiant de l'EOV
-      .map((eov) => [eov.value, eov[labelkey]]);
-
-    setTranslatedEovList(filtered);
-  }, []);
-
   useEffect(() => {
     if (
       typeof window !== "undefined" &&

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -27,5 +27,6 @@
   "select": "Select an option",
   "about_header": "About the map catalog",
   "about_text": "The map catalog is a data exploration tool that allows you to display entries from the OGSL Data Catalog on a map, with the ability to filter results by essential ocean variables* such as sea surface temperature or phytoplankton. By clicking on data points and their spatial extent, the sidebar displays dataset information (title, description, data producer, and links to the Catalog page and data files).",
-  "source": "Source"
+  "source": "Source",
+  "remove_filter": "Remove filter"
 }

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -27,5 +27,6 @@
   "select": "Sélectionnez une option",
   "about_header": "À propos du catalogue cartographique",
   "about_text": "Le catalogue cartographique est un outil d’exploration de données qui permet d’afficher les entrées du Catalogue de données de l’OGSL sur une carte, avec la possibilité de filtrer les résultats par variable océanique* telles que la température de surface de l’eau ou le phytoplancton. En cliquant sur les points de données et leur étendue géospatiale, le panneau latéral affiche les informations du jeu de données (titre, description, producteur de données et liens vers la page du Catalogue et les fichiers de données).",
-  "source": "Source"
+  "source": "Source",
+  "remove_filter": "Retirer le filtre"
 }

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -259,7 +259,7 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
             <span
               role="button"
               tabIndex={0}
-              className="pl-1 text-lg hover:text-accent-500 bg-transparent border-0 p-0 m-0 cursor-pointer"
+              className="pl-1 text-lg hover:text-accent-500 bg-transparent border-0 p-0 m-0 cursor-pointer relative group"
               onClick={(e) => {
                 e.stopPropagation();
                 removeBadge(filter_type);
@@ -267,6 +267,9 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
               aria-label={t.remove_filter}
             >
               <FiDelete />
+              <span className="absolute z-50 left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover:block bg-gray-800 text-white text-xs rounded px-2 py-1 whitespace-nowrap shadow-lg">
+                {t.remove_filter}
+              </span>
             </span>
           </>
         )}

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -237,11 +237,13 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
     }
   };
 
-  const removeBadge = (filterType) => {
+  const removeBadge = (filterType, setQuery) => {
     setBadges((prevBadges) => {
       console.log("Removing badge for filter type:", filterType);
       const updatedBadges = { ...prevBadges };
       delete updatedBadges[filterType];
+      setQuery([]);
+      setCount(0);
       // Reset selected option if the filter type is "filter_date"
       if (filterType === "filter_date") {
         setSelectedOption("");
@@ -265,13 +267,18 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
               {count}
             </span>
             <div>{t[filter_type]}</div>
-            <a
-              className="text-md hover:text-accent-500"
-              onClick={() => removeBadge(filter_type)}
-              title={t.remove_filter}
+            <span
+              role="button"
+              tabIndex={0}
+              className="text-md hover:text-accent-500 bg-transparent border-0 p-0 m-0 cursor-pointer"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeBadge(filter_type, setQuery);
+              }}
+              aria-label={t.remove_filter}
             >
               <IoMdCloseCircle />
-            </a>
+            </span>
           </>
         )) || <div>{t[filter_type]}</div>}
       </Button>

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -212,6 +212,7 @@ function TimeFilter({ lang, setBadges, setSelectedOption }) {
 export function FilterItems({ filter_type, lang, setBadges, options }) {
   const [openModal, setOpenModal] = useState(false);
   const [query, setQuery] = useState([]);
+  const [count, setCount] = useState(0);
   const t = getLocale(lang);
 
   function onCloseModal() {
@@ -221,6 +222,7 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
       setOpenModal(false);
       return;
     }
+    setCount(query.length);
     setBadges((prevBadges) => ({
       ...prevBadges,
       [filter_type]: query,
@@ -250,8 +252,18 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
 
   return (
     <>
-      <Button pill size="xs" onClick={() => setOpenModal(true)}>
-        {t[filter_type]}
+      <Button
+        pill
+        size="xs"
+        className="relative"
+        onClick={() => setOpenModal(true)}
+      >
+        <div>{t[filter_type]}</div>
+        {count > 0 && (
+          <span className="w-4 h-4 ml-1 text-xs border-0 bg-accent-500 text-black rounded-full">
+            {count}
+          </span>
+        )}
       </Button>
       <Modal
         dismissible

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -9,12 +9,12 @@ import {
   Select,
   Datepicker,
 } from "flowbite-react";
-import { useState, useRef, useLayoutEffect } from "react";
+import { useState } from "react";
 import { getLocale } from "@/app/get-locale";
 import { IoFilterOutline } from "react-icons/io5";
 import SidebarButton from "./SidebarButton";
 import { SelectReactComponent } from "./SelectReact";
-import { updateURLWithBadges } from "@/components/UrlParametrization";
+import { IoMdCloseCircle } from "react-icons/io";
 
 // Helper function to format a date range string by removing the time
 function formatDateRangeWithoutTime(value, t) {
@@ -75,29 +75,6 @@ export function SearchFilter({ lang, setBadges }) {
       </Modal>
     </>
   );
-}
-
-export function OptionItems(filter_type, orgList, projList, eovList) {
-  if (filter_type === "organization") {
-    return orgList.map((org) => (
-      <option key={org} value={org}>
-        {org}
-      </option>
-    ));
-  } else if (filter_type === "projects") {
-    return projList.map((proj) => (
-      <option key={proj} value={proj}>
-        {proj}
-      </option>
-    ));
-  } else if (filter_type === "eov") {
-    return eovList.map((eov) => (
-      <option key={eov} value={eov}>
-        {eov}
-      </option>
-    ));
-  }
-  return null;
 }
 
 function TimeFilter({ lang, setBadges, setSelectedOption }) {
@@ -250,20 +227,43 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
     }
   };
 
+  const removeBadge = (filterType) => {
+    setBadges((prevBadges) => {
+      console.log("Removing badge for filter type:", filterType);
+      const updatedBadges = { ...prevBadges };
+      delete updatedBadges[filterType];
+      // Reset selected option if the filter type is "filter_date"
+      if (filterType === "filter_date") {
+        setSelectedOption("");
+      }
+      // Update the URL with the new badges
+      return updatedBadges;
+    });
+  };
+
   return (
     <>
       <Button
         pill
         size="xs"
-        className="relative"
+        className="gap-1 hover:cursor-pointer"
         onClick={() => setOpenModal(true)}
       >
-        <div>{t[filter_type]}</div>
-        {count > 0 && (
-          <span className="w-4 h-4 ml-1 text-xs border-0 bg-accent-500 text-black rounded-full">
-            {count}
-          </span>
-        )}
+        {(count > 0 && (
+          <>
+            <span className="w-4 h-4 text-xs border-0 bg-accent-500 text-black rounded-full">
+              {count}
+            </span>
+            <div>{t[filter_type]}</div>
+            <a
+              className="text-md hover:text-accent-500"
+              onClick={() => removeBadge(filter_type)}
+              title={t.remove_filter}
+            >
+              <IoMdCloseCircle />
+            </a>
+          </>
+        )) || <div>{t[filter_type]}</div>}
       </Button>
       <Modal
         dismissible
@@ -289,52 +289,6 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
   );
 }
 
-// Convert getBadge to a React component so hooks can be used
-function Badge({ filterType, value, lang, removeBadge }) {
-  const t = getLocale(lang);
-  const badgeRef = useRef(null);
-  const [topOffset, setTopOffset] = useState(4);
-
-  useLayoutEffect(() => {
-    if (badgeRef.current) {
-      const height = badgeRef.current.offsetHeight;
-      setTopOffset(Math.max(4, Math.round(height * 0.15)));
-    }
-  }, [value]);
-  // Ensure the badge is not empty before rendering
-  if (value.length === 0) return null;
-
-  return (
-    <div
-      key={filterType}
-      value={value}
-      ref={badgeRef}
-      className="relative max-w-full w-auto flex flex-wrap items-center bg-blue-100 text-black hover:text-black text-sm font-medium px-3 py-1 rounded-full shadow-md hover:bg-blue-200 transition duration-200"
-    >
-      <button
-        className="absolute right-3 hover:text-white rounded-full p-1 transition duration-200"
-        style={{ top: `${topOffset}px`, lineHeight: 1 }}
-        onClick={() => removeBadge(filterType)}
-        aria-label="Remove filter"
-      >
-        &times;
-      </button>
-      <span className="pl-6 pr-6">
-        {filterType === "filter_date" ? (
-          `${t[filterType].toLowerCase()}: ${formatDateRangeWithoutTime(value, t)}`
-        ) : Array.isArray(value) ? (
-          <>
-            {t[filterType]} : <span className="inline md:hidden block" />
-            {value.map((item) => item[1]).join(", ")}
-          </>
-        ) : (
-          `${t[filterType]} : ${value}`
-        )}
-      </span>
-    </div>
-  );
-}
-
 export default function FilterSection({
   lang,
   badges,
@@ -349,19 +303,6 @@ export default function FilterSection({
 
   const toggleAccordion = () => {
     setIsAccordionOpen(!isAccordionOpen);
-  };
-
-  const removeBadge = (filterType) => {
-    setBadges((prevBadges) => {
-      const updatedBadges = { ...prevBadges };
-      delete updatedBadges[filterType];
-      // Reset selected option if the filter type is "filter_date"
-      if (filterType === "filter_date") {
-        setSelectedOption("");
-      }
-      // Update the URL with the new badges
-      return updatedBadges;
-    });
   };
 
   return (
@@ -399,19 +340,6 @@ export default function FilterSection({
             setBadges={setBadges}
             setSelectedOption={setSelectedOption}
           />
-        </div>
-
-        {/* Render Badges */}
-        <div className="m-1 pb-2 flex flex-wrap gap-1 justify-center">
-          {Object.entries(badges).map(([filterType, value]) => (
-            <Badge
-              key={filterType}
-              filterType={filterType}
-              value={value}
-              lang={lang}
-              removeBadge={removeBadge}
-            />
-          ))}
         </div>
       </div>
     </>

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -14,7 +14,7 @@ import { getLocale } from "@/app/get-locale";
 import { IoFilterOutline } from "react-icons/io5";
 import SidebarButton from "./SidebarButton";
 import { SelectReactComponent } from "./SelectReact";
-import { IoMdCloseCircle } from "react-icons/io";
+import { FiDelete } from "react-icons/fi";
 import { updateURLWithBadges } from "@/components/UrlParametrization";
 
 // Helper function to format a date range string by removing the time
@@ -259,14 +259,14 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
             <span
               role="button"
               tabIndex={0}
-              className="text-md hover:text-accent-500 bg-transparent border-0 p-0 m-0 cursor-pointer"
+              className="pl-1 text-lg hover:text-accent-500 bg-transparent border-0 p-0 m-0 cursor-pointer"
               onClick={(e) => {
                 e.stopPropagation();
                 removeBadge(filter_type);
               }}
               aria-label={t.remove_filter}
             >
-              <IoMdCloseCircle />
+              <FiDelete />
             </span>
           </>
         )}

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -52,7 +52,12 @@ export function SearchFilter({ lang, setBadges }) {
 
   return (
     <>
-      <Button pill size="xs" onClick={() => setOpenModal(true)}>
+      <Button
+        className="bg-primary-500 hover:cursor-pointer"
+        pill
+        size="xs"
+        onClick={() => setOpenModal(true)}
+      >
         {t.search}
       </Button>
       <Modal
@@ -110,7 +115,12 @@ function TimeFilter({ lang, setBadges, setSelectedOption }) {
 
   return (
     <>
-      <Button pill size="xs" onClick={() => setOpenModal(true)}>
+      <Button
+        className="bg-primary-500 hover:cursor-pointer"
+        pill
+        size="xs"
+        onClick={() => setOpenModal(true)}
+      >
         {t.time}
       </Button>
       <Modal
@@ -246,7 +256,7 @@ export function FilterItems({ filter_type, lang, setBadges, options }) {
       <Button
         pill
         size="xs"
-        className="gap-1 hover:cursor-pointer"
+        className="gap-1 bg-primary-500 hover:cursor-pointer"
         onClick={() => setOpenModal(true)}
       >
         {(count > 0 && (

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -209,14 +209,7 @@ function TimeFilter({ lang, setBadges, setSelectedOption }) {
   );
 }
 
-export function FilterItems({
-  filter_type,
-  lang,
-  setBadges,
-  orgList,
-  projList,
-  eovList,
-}) {
+export function FilterItems({ filter_type, lang, setBadges, options }) {
   const [openModal, setOpenModal] = useState(false);
   const [query, setQuery] = useState([]);
   const t = getLocale(lang);
@@ -273,9 +266,7 @@ export function FilterItems({
         <ModalBody>
           <SelectReactComponent
             filter_type={filter_type}
-            orgList={orgList}
-            projList={projList}
-            eovList={eovList}
+            options={options}
             setQuery={setQuery}
             query={query}
             lang={lang}
@@ -377,25 +368,19 @@ export default function FilterSection({
             filter_type="organization"
             lang={lang}
             setBadges={setBadges}
-            orgList={orgList}
-            projList={projList}
-            eovList={eovList}
+            options={orgList.map((org) => ({ label: org, value: org }))} // Convert to array of tuples
           />
           <FilterItems
             filter_type="projects"
             lang={lang}
             setBadges={setBadges}
-            orgList={orgList}
-            projList={projList}
-            eovList={eovList}
+            options={projList.map((proj) => ({ label: proj, value: proj }))} // Convert to array of tuples
           />
           <FilterItems
             filter_type="eov"
             lang={lang}
             setBadges={setBadges}
-            orgList={orgList}
-            projList={projList}
-            eovList={eovList}
+            options={eovList.map((eov) => ({ label: eov[0], value: eov[1] }))} // Convert to array of tuples
           />
           <TimeFilter
             lang={lang}

--- a/components/FilterSection.js
+++ b/components/FilterSection.js
@@ -54,12 +54,15 @@ export function SearchFilter({ lang, setBadges }) {
   return (
     <>
       <Button
-        className="bg-primary-500 hover:cursor-pointer"
+        className="bg-primary-500 hover:cursor-pointer px-3"
         pill
         size="xs"
         onClick={() => setOpenModal(true)}
       >
         {t.search}
+        {query && query.trim() !== "" && (
+          <span className="h-4 text-xs">: {query}</span>
+        )}
       </Button>
       <Modal
         dismissible
@@ -76,7 +79,7 @@ export function SearchFilter({ lang, setBadges }) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="rounded-lg border-0 text-lg  peer-focus:text-black peer-focus:dark:text-white text-black dark:text-white"
+          className="rounded-lg border-0 text-lg text-black dark:text-white focus:text-black focus:dark:text-white"
         />
       </Modal>
     </>

--- a/components/SelectReact.js
+++ b/components/SelectReact.js
@@ -1,6 +1,7 @@
 import SelectReact from "react-select";
 import makeAnimated from "react-select/animated";
 import { getLocale } from "@/app/get-locale";
+import colors from "tailwindcss/colors";
 
 export function SelectReactComponent({
   filter_type,
@@ -56,54 +57,37 @@ export function SelectReactComponent({
             backgroundColor:
               typeof window !== "undefined" &&
               window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#0f172a" // Tailwind dark:bg-primary-900
-                : "#fff", // Light mode: white
+                ? colors.slate[900]
+                : colors.white,
             color:
               typeof window !== "undefined" &&
               window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#f3f4f6" // Tailwind gray-100
-                : "#000000", // Light mode: black
+                ? colors.gray[100]
+                : colors.black,
           }),
           option: (base, state) => ({
             ...base,
             backgroundColor: state.isFocused
               ? typeof window !== "undefined" &&
                 window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#1e293b" // Tailwind dark:bg-primary-700
-                : "#dbeafe" // Tailwind bg-primary-100
+                ? colors.slate[700]
+                : colors.blue[100]
               : typeof window !== "undefined" &&
                   window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#0f172a" // Tailwind dark:bg-primary-900
-                : "#fff", // Light mode: white
+                ? colors.slate[900]
+                : colors.white,
             color:
               typeof window !== "undefined" &&
               window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#f3f4f6" // Tailwind gray-100
-                : "#000000", // Light mode: black
-          }),
-          multiValue: (base) => ({
-            ...base,
-            backgroundColor:
-              typeof window !== "undefined" &&
-              window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#0f172a" // Tailwind dark:bg-primary-900
-                : "#bfdbfe", // Tailwind bg-primary-200
-            color: "#ffffff", // Tailwind text-gray-500
-          }),
-          multiValueLabel: (base) => ({
-            ...base,
-            color:
-              typeof window !== "undefined" &&
-              window.matchMedia("(prefers-color-scheme: dark)").matches
-                ? "#ffffff" // Tailwind dark:bg-primary-900
-                : "#000000", // Tailwind bg-primary-200
+                ? colors.gray[100]
+                : colors.black,
           }),
           multiValueRemove: (base) => ({
             ...base,
-            color: "#6b7280",
+            color: colors.gray[600],
             ":hover": {
-              backgroundColor: "#1e293b", // Tailwind dark:bg-primary-700
-              color: "#9ca3af", // Tailwind dark:text-gray-400
+              backgroundColor: colors.slate[700],
+              color: colors.gray[400],
             },
           }),
         }}

--- a/components/SelectReact.js
+++ b/components/SelectReact.js
@@ -5,9 +5,7 @@ import colors from "tailwindcss/colors";
 
 export function SelectReactComponent({
   filter_type,
-  orgList,
-  projList,
-  eovList,
+  options,
   setQuery,
   query,
   lang,
@@ -20,16 +18,7 @@ export function SelectReactComponent({
       <SelectReact
         id={`${t[filter_type]?.toLowerCase?.() || filter_type}-select`}
         isMulti
-        options={(filter_type === "organization"
-          ? orgList
-          : filter_type === "projects"
-            ? projList
-            : eovList
-        ).map((item) =>
-          filter_type === "eov"
-            ? { value: item[0], label: item[1] }
-            : { value: item, label: item },
-        )}
+        options={options}
         value={query.map((val) => ({
           value: val[0],
           label: val[1],


### PR DESCRIPTION
Unify filter components to use a single options prop, implement a counter for selected items, and apply Tailwind CSS colors for improved styling. Remove unused functions to streamline the codebase.

J'ai fait quelques modifications au code des filtres en retitré le badge du UI.

Les badges demeurent dans la mécanique par contre. 
J'ai par contre quelques ennuis toujours:

- [ ] Lorsque tous les items d'un filtre sont sélectionner, le dernier terme demeure toujours dans l'URL et sur le badge
- [ ] Ajout d'une indication que les filtres recherche et temps sont actifs.